### PR TITLE
Add revision history UI

### DIFF
--- a/assets/stylesheets/dashboard-theme.css
+++ b/assets/stylesheets/dashboard-theme.css
@@ -77,3 +77,8 @@ body.ea-dark-scheme img.img-light {
 body:not(.ea-dark-scheme) img.img-dark {
   display: none;
 }
+
+.text-monospace {
+  font-family: var(--font-family-monospace);
+  font-size: 13px;
+}

--- a/src/Controller/Dashboard/DashboardPackagesInfoController.php
+++ b/src/Controller/Dashboard/DashboardPackagesInfoController.php
@@ -4,7 +4,6 @@ namespace CodedMonkey\Dirigent\Controller\Dashboard;
 
 use CodedMonkey\Dirigent\Attribute\IsGrantedAccess;
 use CodedMonkey\Dirigent\Attribute\MapPackage;
-use CodedMonkey\Dirigent\Doctrine\Entity\Metadata;
 use CodedMonkey\Dirigent\Doctrine\Entity\Package;
 use CodedMonkey\Dirigent\Doctrine\Entity\PackageProvideLink;
 use CodedMonkey\Dirigent\Doctrine\Entity\PackageRequireLink;
@@ -23,6 +22,7 @@ class DashboardPackagesInfoController extends AbstractController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly MetadataRepository $metadataRepository,
     ) {
     }
 
@@ -31,7 +31,7 @@ class DashboardPackagesInfoController extends AbstractController
      */
     #[Route('/packages/{package}', name: 'dashboard_packages_info', requirements: ['package' => MapPackage::PACKAGE_REGEX])]
     #[IsGrantedAccess]
-    public function info(#[MapPackage] Package $package): Response
+    public function info(Request $request, #[MapPackage] Package $package): Response
     {
         $version = $package->getLatestVersion();
 
@@ -39,16 +39,32 @@ class DashboardPackagesInfoController extends AbstractController
             return $this->redirectToRoute('dashboard_packages_versions', ['package' => $package->getName()]);
         }
 
-        return $this->versionInfo($package, $version);
+        return $this->versionInfo($request, $package, $version, latest: true);
     }
 
     #[Route('/packages/{package}/versions/{version}', name: 'dashboard_packages_version_info', requirements: ['package' => MapPackage::PACKAGE_REGEX, 'version' => '.*'])]
     #[IsGrantedAccess]
-    public function versionInfo(#[MapPackage] Package $package, #[MapPackage] Version $version): Response
-    {
-        /** @var MetadataRepository $metadataRepository */
-        $metadataRepository = $this->entityManager->getRepository(Metadata::class);
-        $metadataRepository->fetchMetadataCollections($version->getCurrentMetadata());
+    public function versionInfo(
+        Request $request,
+        #[MapPackage] Package $package,
+        #[MapPackage] Version $version,
+        bool $latest = false,
+    ): Response {
+        $metadata = $version->getCurrentMetadata();
+        $revision = $request->query->getInt('revision');
+
+        // Only check for a revision number if the route is for a specific version: $latest !== true
+        if ($revision > 0 && !$latest) {
+            $metadata = $this->metadataRepository->findOneBy(['version' => $version, 'revision' => $revision]);
+
+            if (null === $metadata) {
+                throw $this->createNotFoundException('The revision does not exist.');
+            }
+        }
+
+        $this->metadataRepository->fetchMetadataCollections($metadata);
+
+        $metadataCount = $this->metadataRepository->getMetadataCountForVersion($version);
 
         $dependentCount = $this->entityManager->getRepository(PackageRequireLink::class)->count(['linkedPackageName' => $package->getName()]);
         $implementationCount = $this->entityManager->getRepository(PackageProvideLink::class)->count(['linkedPackageName' => $package->getName(), 'implementation' => true]);
@@ -58,12 +74,29 @@ class DashboardPackagesInfoController extends AbstractController
         return $this->render('dashboard/packages/package_info.html.twig', [
             'package' => $package,
             'version' => $version,
-            'metadata' => $version->getCurrentMetadata(),
+            'metadata' => $metadata,
 
             'dependentCount' => $dependentCount,
             'implementationCount' => $implementationCount,
+            'metadataCount' => $metadataCount,
             'providerCount' => $providerCount,
             'suggesterCount' => $suggesterCount,
+        ]);
+    }
+
+    #[Route('/packages/{package}/revisions/{version}', name: 'dashboard_packages_version_metadata_list', requirements: ['package' => MapPackage::PACKAGE_REGEX, 'version' => '.*'])]
+    #[IsGrantedAccess]
+    public function versionMetadataList(
+        #[MapPackage] Package $package,
+        #[MapPackage] Version $version,
+    ): Response {
+        $metadataCollection = $this->metadataRepository->getMetadataCollectionForVersion($version);
+
+        return $this->render('dashboard/packages/package_version_revisions.html.twig', [
+            'package' => $package,
+            'version' => $version,
+
+            'metadataCollection' => $metadataCollection,
         ]);
     }
 

--- a/src/Controller/Dashboard/DashboardPackagesInfoController.php
+++ b/src/Controller/Dashboard/DashboardPackagesInfoController.php
@@ -106,6 +106,7 @@ class DashboardPackagesInfoController extends AbstractController
     {
         return $this->render('dashboard/packages/package_versions.html.twig', [
             'package' => $package,
+            'metadataCounts' => $this->metadataRepository->getMetadataCountsForPackage($package),
         ]);
     }
 

--- a/src/Doctrine/Entity/Metadata.php
+++ b/src/Doctrine/Entity/Metadata.php
@@ -466,6 +466,16 @@ class Metadata extends TrackedEntity implements \Stringable
         return self::getOrderedCollection($this->keywords, $raw);
     }
 
+    public function isCurrentMetadata(): bool
+    {
+        return $this->version->hasCurrentMetadata() && $this === $this->version->getCurrentMetadata();
+    }
+
+    public function getReference(): ?string
+    {
+        return $this->getSourceReference() ?? $this->getDistReference();
+    }
+
     public function hasSource(): bool
     {
         return null !== $this->source;

--- a/src/Doctrine/Repository/MetadataRepository.php
+++ b/src/Doctrine/Repository/MetadataRepository.php
@@ -3,6 +3,7 @@
 namespace CodedMonkey\Dirigent\Doctrine\Repository;
 
 use CodedMonkey\Dirigent\Doctrine\Entity\Metadata;
+use CodedMonkey\Dirigent\Doctrine\Entity\Package;
 use CodedMonkey\Dirigent\Doctrine\Entity\Version;
 use CodedMonkey\Dirigent\Entity\MetadataLinkType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -53,6 +54,30 @@ class MetadataRepository extends ServiceEntityRepository
             ['version' => $version],
             ['revision' => Order::Descending->value],
         );
+    }
+
+    /**
+     * Returns a map of version ID => metadata count for all versions of the given package.
+     *
+     * @return array<int, int>
+     */
+    public function getMetadataCountsForPackage(Package $package): array
+    {
+        $rows = $this->createQueryBuilder('metadata')
+            ->select('IDENTITY(metadata.version) as version_id, COUNT(metadata.id) as revision_count')
+            ->join('metadata.version', 'version')
+            ->where('version.package = :package')
+            ->groupBy('metadata.version')
+            ->setParameter('package', $package)
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[(int) $row['version_id']] = (int) $row['revision_count'];
+        }
+
+        return $counts;
     }
 
     /**

--- a/src/Doctrine/Repository/MetadataRepository.php
+++ b/src/Doctrine/Repository/MetadataRepository.php
@@ -3,8 +3,10 @@
 namespace CodedMonkey\Dirigent\Doctrine\Repository;
 
 use CodedMonkey\Dirigent\Doctrine\Entity\Metadata;
+use CodedMonkey\Dirigent\Doctrine\Entity\Version;
 use CodedMonkey\Dirigent\Entity\MetadataLinkType;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\Order;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -38,6 +40,19 @@ class MetadataRepository extends ServiceEntityRepository
         if ($flush) {
             $this->getEntityManager()->flush();
         }
+    }
+
+    public function getMetadataCountForVersion(Version $version): int
+    {
+        return $this->count(['version' => $version]);
+    }
+
+    public function getMetadataCollectionForVersion(Version $version): array
+    {
+        return $this->findBy(
+            ['version' => $version],
+            ['revision' => Order::Descending->value],
+        );
     }
 
     /**

--- a/templates/dashboard/packages/_package_header.html.twig
+++ b/templates/dashboard/packages/_package_header.html.twig
@@ -2,10 +2,13 @@
 {% set attrActive = 'class="nav-link active" aria-current="page"' %}
 {% set attr = 'class="nav-link text-primary"' %}
 
-<ul class="nav nav-pills nav-justified d-grid d-md-flex gap-1 pb-3 mb-3 border-bottom">
+<ul class="nav nav-pills nav-justified d-grid d-md-flex gap-1 pb-2 mb-3 border-bottom">
   <li class="nav-item">
     {% if package.versions|length > 0 %}
-      {% set packageInfoUrl = path('dashboard_packages_info', {package: package.name}) %}
+      {% set packageInfoUrl = version is defined
+        ? path('dashboard_packages_version_info', {package: package.name, version: version.name})
+        : path('dashboard_packages_info', {package: package.name})
+      %}
       <a {{ (currentPage == 'info' ? attrActive : attr)|raw }} href="{{ packageInfoUrl }}">{{ 'Info'|trans }}</a>
     {% else %}
       <span class="nav-link disabled">{{ 'Info'|trans }}</span>

--- a/templates/dashboard/packages/package_info.html.twig
+++ b/templates/dashboard/packages/package_info.html.twig
@@ -100,66 +100,99 @@
     {% endif %}
   </div>
 
-  <div class="row border-bottom pb-3 mb-3">
-    {{ _self.linkBlock('Requires', metadata.requireLinks) }}
-    {{ _self.linkBlock('Requires (dev)', metadata.devRequireLinks) }}
-    {{ _self.provideBlock(metadata.provideLinks) }}
-    {{ _self.linkBlock('Suggests', metadata.suggestLinks) }}
-    {{ _self.linkBlock('Conflicts', metadata.conflictLinks) }}
-    {{ _self.linkBlock('Replaces', metadata.replaceLinks) }}
+  <div class="border-bottom mb-3">
+    <div class="row g-0">
+      {{ _self.linkBlock('Requires', metadata.requireLinks) }}
+      {{ _self.linkBlock('Requires (dev)', metadata.devRequireLinks) }}
+      {{ _self.provideBlock(metadata.provideLinks) }}
+      {{ _self.linkBlock('Suggests', metadata.suggestLinks) }}
+      {{ _self.linkBlock('Conflicts', metadata.conflictLinks) }}
+      {{ _self.linkBlock('Replaces', metadata.replaceLinks) }}
+    </div>
   </div>
 
-  <div class="row border-bottom pb-3 mb-3">
-    <div class="col-md-6">
-      {% if metadata.hasSource() %}
-        <div class="h5">
-          {{ 'Source'|trans }}
-          <span class="badge text-bg-secondary">{{ metadata.sourceType }}</span>
-        </div>
-
-        <div class="mb-2">
-          <code>{{ metadata.sourceUrl }}</code>
-        </div>
-
-        <div class="mb-2">
-          {{ 'Reference'|trans }}: <code>{{ metadata.sourceReference }}</code>
-        </div>
-
-        <div class="mb-2">
-          {% set browseUrl = metadata.browsableRepositoryUrl %}
-          {% if browseUrl %}
-            <a class="btn btn-sm btn-secondary" href="{{ browseUrl }}">
-              <span class="fa-solid fa-code me-1" aria-hidden="true"></span>
-              {{ 'Browse code'|trans }}
+  <div class="border-bottom pb-3 mb-3">
+    {% if metadataCount > 1 %}
+      <div class="bg-body-tertiary border border-warning-subtle px-3 py-2 mb-3 rounded">
+        <p>
+          {{ 'Multiple revisions found for version %version% of package %package%'|trans({
+            '%package%': "<strong>#{package.name|escape}</strong>",
+            '%version%': "<strong>#{version.name|escape}</strong>",
+          })|raw }}
+        </p>
+        {% if not metadata.isCurrentMetadata %}
+          <p class="text-warning">
+            <strong>
+              {{ "You're viewing an inactive revision of this package"|trans }}
+            </strong>
+          </p>
+        {% endif %}
+        <div class="btn-toolbar gap-1">
+          <a class="btn btn-sm btn-secondary" href="{{ path('dashboard_packages_version_metadata_list', {package: package.name, version: version.name}) }}">
+            <span class="fa-solid fa-list me-1" aria-hidden="true"></span>
+            <span class="btn-label">{{ 'Revisions'|trans }}</span>
+          </a>
+          {% if not metadata.isCurrentMetadata %}
+            <a class="btn btn-sm btn-secondary" href="{{ path('dashboard_packages_version_info', {package: package.name, version: version.name}) }}">
+              <span class="fa-solid fa-code-commit me-1" aria-hidden="true"></span>
+              <span class="btn-label">{{ 'Current revision'|trans }}</span>
             </a>
           {% endif %}
         </div>
-      {% else %}
-        <div class="h5">{{ 'Source'|trans }}</div>
-        -
-      {% endif %}
-    </div>
-    <div class="col-md-6">
-      {% if metadata.hasDist() %}
-        <div class="h5">
-          {{ 'Distribution'|trans }}
-          <span class="badge text-bg-secondary">{{ metadata.distType }}</span>
-        </div>
+      </div>
+    {% endif %}
+    <div class="row g-0">
+      <div class="col-md-6">
+        {% if metadata.hasSource() %}
+          <div class="h5">
+            {{ 'Source'|trans }}
+            <span class="badge text-bg-secondary">{{ metadata.sourceType }}</span>
+          </div>
 
-        <div class="mb-2">
-          {{ 'Reference'|trans }}: <code>{{ metadata.distReference }}</code>
-        </div>
+          <div class="mb-2">
+            <code>{{ metadata.sourceUrl }}</code>
+          </div>
 
-        <div class="mb-2">
-          <a class="btn btn-sm btn-secondary" href="{{ metadata.distUrl }}" download>
-            <span class="fa-solid fa-download me-1" aria-hidden="true"></span>
-            {{ 'Download' }}
-          </a>
-        </div>
-      {% else %}
-        <div class="h5">{{ 'Distribution'|trans }}</div>
-        -
-      {% endif %}
+          <div class="mb-2">
+            {{ 'Reference'|trans }}: <code>{{ metadata.sourceReference }}</code>
+          </div>
+
+          <div>
+            {% set browseUrl = metadata.browsableRepositoryUrl %}
+            {% if browseUrl %}
+              <a class="btn btn-sm btn-secondary" href="{{ browseUrl }}">
+                <span class="fa-solid fa-code me-1" aria-hidden="true"></span>
+                <span class="btn-label">{{ 'Browse code'|trans }}</span>
+              </a>
+            {% endif %}
+          </div>
+        {% else %}
+          <div class="h5">{{ 'Source'|trans }}</div>
+          -
+        {% endif %}
+      </div>
+      <div class="col-md-6">
+        {% if metadata.hasDist() %}
+          <div class="h5">
+            {{ 'Distribution'|trans }}
+            <span class="badge text-bg-secondary">{{ metadata.distType }}</span>
+          </div>
+
+          <div class="mb-2">
+            {{ 'Reference'|trans }}: <code>{{ metadata.distReference }}</code>
+          </div>
+
+          <div>
+            <a class="btn btn-sm btn-secondary" href="{{ metadata.distUrl }}" download>
+              <span class="fa-solid fa-download me-1" aria-hidden="true"></span>
+              <span class="btn-label">{{ 'Download' }}</span>
+            </a>
+          </div>
+        {% else %}
+          <div class="h5">{{ 'Distribution'|trans }}</div>
+          -
+        {% endif %}
+      </div>
     </div>
   </div>
 

--- a/templates/dashboard/packages/package_version_revisions.html.twig
+++ b/templates/dashboard/packages/package_version_revisions.html.twig
@@ -1,0 +1,37 @@
+{% extends 'dashboard/packages/package_base.html.twig' %}
+
+{% block page_title %}
+  {%- apply spaceless -%}
+    {{ package.name }}
+    <small>{{ version.extendedName }}</small>
+  {%- endapply -%}
+{% endblock %}
+
+{% block page_content %}
+  {{ include('dashboard/packages/_package_header.html.twig') }}
+
+  <h2 class="h4">{{ 'Revisions'|trans }}</h2>
+
+  <div class="list-group list-group-flush border-bottom mb-3">
+    {% for metadata in metadataCollection %}
+      {% set infoUrl = metadata.isCurrentMetadata
+        ? path('dashboard_packages_version_info', {package: package.name, version: version.name})
+        : path('dashboard_packages_version_info', {package: package.name, version: version.name, revision: metadata.revision})
+      %}
+      <a href="{{ infoUrl }}" class="list-group-item">
+        <div class="d-flex justify-content-between">
+          <div>
+            <span>{{ 'Revision'|trans }} {{ metadata.revision }}: <span class="text-monospace">{{ metadata.reference }}</span></span>
+          </div>
+          <span class="text-muted">{{ metadata.releasedAt ? metadata.releasedAt.format('Y-m-d') }}</span>
+        </div>
+        <div>
+          <span>{{ 'Indexed on %date%'|trans({'%date%': metadata.createdAt.format('Y-m-d')}) }}</span>
+          {% if metadata.isCurrentMetadata %}
+            <span class="badge text-bg-secondary ms-1">{{ 'Current revision'|trans }}</span>
+          {% endif %}
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+{% endblock %}

--- a/templates/dashboard/packages/package_versions.html.twig
+++ b/templates/dashboard/packages/package_versions.html.twig
@@ -16,10 +16,10 @@
   {% endapply %}
 
   {% if package.versions|length > 0 %}
-    {{ _self.versionList('Latest versions', package.activeVersions) }}
-    {{ _self.versionList('Development versions', package.devVersions) }}
-    {{ _self.versionList('Historical versions', package.historicalVersions) }}
-    {{ _self.versionList('Development branch versions', package.devBranchVersions) }}
+    {{ _self.versionList('Latest versions', package.activeVersions, metadataCounts) }}
+    {{ _self.versionList('Development versions', package.devVersions, metadataCounts) }}
+    {{ _self.versionList('Historical versions', package.historicalVersions, metadataCounts) }}
+    {{ _self.versionList('Development branch versions', package.devBranchVersions, metadataCounts) }}
   {% else %}
     <table class="table datagrid datagrid-empty">
       <tbody>
@@ -46,22 +46,30 @@
   {% endif %}
 {% endblock %}
 
-{% macro versionList(title, versions) %}
+{% macro versionList(title, versions, metadataCounts) %}
   {% if versions|length %}
     <h2 class="h4">{{ title|trans }}</h2>
     <div class="list-group list-group-flush border-bottom mb-3">
       {% for version in versions %}
-        {{ _self.versionListItem(version) }}
+        {{ _self.versionListItem(version, metadataCounts) }}
       {% endfor %}
     </div>
   {% endif %}
 {% endmacro %}
 
-{% macro versionListItem(version) %}
+{% macro versionListItem(version, metadataCounts) %}
   {% set packageVersionInfoUrl = path('dashboard_packages_version_info', {package: version.package.name, version: version.name}) %}
   <a href="{{ packageVersionInfoUrl }}" class="list-group-item">
     <div class="d-flex justify-content-between">
-      <span>{{ version.extendedName }}</span>
+      <span>
+        <span>{{ version.extendedName }}</span>
+        {% if metadataCounts[version.id] > 1 %}
+          <span class="text-muted ms-1" title="{{ 'This version has multiple revisions'|trans }}">
+            <span class="fa-solid fa-file-alt" aria-hidden="true"></span>
+            <span class="visually-hidden">{{ 'This version has multiple revisions'|trans }}</span>
+          </span>
+        {% endif %}
+      </span>
       <span class="text-muted">{{ version.currentMetadata.releasedAt ? version.currentMetadata.releasedAt.format('Y-m-d') }}</span>
     </div>
   </a>

--- a/tests/FunctionalTests/Controller/Dashboard/DashboardPackagesInfoControllerTest.php
+++ b/tests/FunctionalTests/Controller/Dashboard/DashboardPackagesInfoControllerTest.php
@@ -50,6 +50,16 @@ class DashboardPackagesInfoControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
     }
 
+    public function testPackageMetadataList(): void
+    {
+        $client = static::createClient();
+        $this->loginUser();
+
+        $client->request('GET', '/packages/psr/log/revisions/1.0.0');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+    }
+
     public function testVersions(): void
     {
         $client = static::createClient();

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -72,6 +72,14 @@ Requires: Requires
 Requires (dev): Requires (dev)
 Suggests: Suggests
 
+# Package labels (Revisions)
+Current revision: Current revision
+Indexed on %date%: Indexed on %date%
+Multiple revisions found for version %version% of package %package%: Multiple revisions found for version %version% of package %package%.
+Revision: Revision
+Revisions: Revisions
+You're viewing an inactive revision of this package: You're viewing an inactive revision of this package.
+
 # Package labels (Statistics)
 Daily installations: Daily installations
 Daily installations per version: Daily installations per version

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -78,6 +78,7 @@ Indexed on %date%: Indexed on %date%
 Multiple revisions found for version %version% of package %package%: Multiple revisions found for version %version% of package %package%.
 Revision: Revision
 Revisions: Revisions
+This version has multiple revisions: This version has multiple revisions
 You're viewing an inactive revision of this package: You're viewing an inactive revision of this package.
 
 # Package labels (Statistics)


### PR DESCRIPTION
Adds a new page containing a list of revisions for package versions that have multiple metadata

See https://github.com/codedmonkey/dirigent/issues/8 for more information.