### PR TITLE
Allow pinning of package version revisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Dirigent is a free and open package registry for Composer, the PHP package manag
 ### Project
 
 - Environment variables are stored in `.env.dirigent` and `.env.dirigent.*` (not `.env`).
+- When adding new user-facing text, add the corresponding entries to the relevant file in `translations/` (e.g. `translations/messages.en.yaml`). Keep keys in their existing section and alphabetical order.
 
 ### PHP
 

--- a/migrations/Version20260519093651.php
+++ b/migrations/Version20260519093651.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260519093651 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add pinned property to version table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE version ADD pinned BOOLEAN DEFAULT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            UPDATE version SET pinned = false
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE version ALTER pinned SET NOT NULL
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE version DROP pinned
+        SQL);
+    }
+}

--- a/src/Controller/Dashboard/DashboardPackagesInfoController.php
+++ b/src/Controller/Dashboard/DashboardPackagesInfoController.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class DashboardPackagesInfoController extends AbstractController
 {
@@ -90,13 +91,53 @@ class DashboardPackagesInfoController extends AbstractController
         #[MapPackage] Package $package,
         #[MapPackage] Version $version,
     ): Response {
-        $metadataCollection = $this->metadataRepository->getMetadataCollectionForVersion($version);
+        $metadataCollection = $this->metadataRepository->findAllMetadataForVersion($version);
 
         return $this->render('dashboard/packages/package_version_revisions.html.twig', [
             'package' => $package,
             'version' => $version,
 
             'metadataCollection' => $metadataCollection,
+        ]);
+    }
+
+    #[Route('/packages/{package}/pin-metadata/{version}', name: 'dashboard_packages_version_pin', requirements: ['package' => MapPackage::PACKAGE_REGEX, 'version' => '.*'], methods: ['POST'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function pinMetadata(
+        Request $request,
+        #[MapPackage] Package $package,
+        #[MapPackage] Version $version,
+    ): Response {
+        $action = (string) $request->request->get('action');
+
+        if (!$this->isCsrfTokenValid($action . '-revision-' . $version->getId(), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if ('pin' === $action) {
+            $revision = $request->request->getInt('revision');
+            if (null === $metadata = $this->metadataRepository->findMetadataForVersion($version, $revision)) {
+                throw $this->createNotFoundException('The revision does not exist.');
+            }
+
+            $version->setCurrentMetadata($metadata);
+            $version->setPinned(true);
+        } elseif ('unpin' === $action) {
+            if (null === $latestMetadata = $this->metadataRepository->findLatestMetadataForVersion($version)) {
+                throw $this->createNotFoundException('No metadata available for this version.');
+            }
+
+            $version->setCurrentMetadata($latestMetadata);
+            $version->setPinned(false);
+        } else {
+            throw $this->createNotFoundException('Invalid action.');
+        }
+
+        $this->entityManager->flush();
+
+        return $this->redirectToRoute('dashboard_packages_version_info', [
+            'package' => $package->getName(),
+            'version' => $version->getName(),
         ]);
     }
 

--- a/src/Doctrine/Entity/Version.php
+++ b/src/Doctrine/Entity/Version.php
@@ -23,6 +23,12 @@ class Version extends TrackedEntity implements \Stringable
     #[ORM\Column]
     private bool $development;
 
+    /**
+     * Whether the current metadata is pinned.
+     */
+    #[ORM\Column]
+    private bool $pinned = false;
+
     #[ORM\Column]
     private bool $pruned = false;
 
@@ -95,6 +101,16 @@ class Version extends TrackedEntity implements \Stringable
     public function setDevelopment(bool $development): void
     {
         $this->development = $development;
+    }
+
+    public function isPinned(): bool
+    {
+        return $this->pinned;
+    }
+
+    public function setPinned(bool $pinned): void
+    {
+        $this->pinned = $pinned;
     }
 
     public function isPruned(): bool

--- a/src/Doctrine/Repository/MetadataRepository.php
+++ b/src/Doctrine/Repository/MetadataRepository.php
@@ -48,11 +48,26 @@ class MetadataRepository extends ServiceEntityRepository
         return $this->count(['version' => $version]);
     }
 
-    public function getMetadataCollectionForVersion(Version $version): array
+    public function findMetadataForVersion(Version $version, int $revision): ?Metadata
+    {
+        return $this->findOneBy(
+            criteria: ['version' => $version, 'revision' => $revision],
+        );
+    }
+
+    public function findLatestMetadataForVersion(Version $version): ?Metadata
+    {
+        return $this->findOneBy(
+            criteria: ['version' => $version],
+            orderBy: ['revision' => Order::Descending->value],
+        );
+    }
+
+    public function findAllMetadataForVersion(Version $version): array
     {
         return $this->findBy(
-            ['version' => $version],
-            ['revision' => Order::Descending->value],
+            criteria: ['version' => $version],
+            orderBy: ['revision' => Order::Descending->value],
         );
     }
 

--- a/src/Package/PackageMetadataResolver.php
+++ b/src/Package/PackageMetadataResolver.php
@@ -213,7 +213,7 @@ readonly class PackageMetadataResolver
 
         // Remove outdated versions
         foreach ($existingVersionMetadata as $version) {
-            $removeVersion = $version->isDevelopment() ? !$this->retainPrunedVersionsDev : !$this->retainPrunedVersionsTagged;
+            $removeVersion = !$version->isPinned() && ($version->isDevelopment() ? !$this->retainPrunedVersionsDev : !$this->retainPrunedVersionsTagged);
             if ($removeVersion) {
                 $this->entityManager->remove($version);
             } elseif (!$version->isPruned()) {
@@ -236,13 +236,17 @@ readonly class PackageMetadataResolver
 
         if (null === $currentMetadata || $this->hasMetadataChanged($currentMetadata, $metadata)) {
             $metadata->setRevision($version->getNextRevision(increment: true));
-            $version->setCurrentMetadata($metadata);
 
             $this->entityManager->persist($metadata);
 
-            $removePreviousMetadata = $version->isDevelopment() ? !$this->retainStaleRevisionsDev : !$this->retainStaleRevisionsTagged;
-            if (null !== $currentMetadata && $removePreviousMetadata) {
-                $this->entityManager->remove($currentMetadata);
+            $retainStaleRevisions = $version->isDevelopment() ? $this->retainStaleRevisionsDev : $this->retainStaleRevisionsTagged;
+            if (!$version->isPinned() || !$retainStaleRevisions) {
+                $version->setCurrentMetadata($metadata);
+                $version->setPinned(false);
+
+                if (null !== $currentMetadata && !$retainStaleRevisions) {
+                    $this->entityManager->remove($currentMetadata);
+                }
             }
         }
 

--- a/templates/dashboard/packages/package_info.html.twig
+++ b/templates/dashboard/packages/package_info.html.twig
@@ -120,16 +120,29 @@
             '%version%': "<strong>#{version.name|escape}</strong>",
           })|raw }}
         </p>
-        {% if not metadata.isCurrentMetadata %}
-          <p class="text-warning">
-            <strong>
-              {{ "You're viewing an inactive revision of this package"|trans }}
-            </strong>
-          </p>
+        {% if not metadata.isCurrentMetadata or version.pinned %}
+          <div class="mb-3">
+            {% if not metadata.isCurrentMetadata %}
+              <div class="d-flex align-items-center">
+                <span class="fa-solid fa-fw fa-code-branch text-warning me-1" aria-hidden="true"></span>
+                <strong>
+                  {{ "You're viewing an inactive revision of this package"|trans }}
+                </strong>
+              </div>
+            {% endif %}
+            {% if version.pinned %}
+              <div class="d-flex align-items-center">
+                <span class="fa-solid fa-fw fa-thumbtack text-warning me-1" aria-hidden="true"></span>
+                <strong>
+                  {{ 'This version is pinned. Future updates will not change the active metadata until it is unpinned.'|trans }}
+                </strong>
+              </div>
+            {% endif %}
+          </div>
         {% endif %}
         <div class="btn-toolbar gap-1">
           <a class="btn btn-sm btn-secondary" href="{{ path('dashboard_packages_version_metadata_list', {package: package.name, version: version.name}) }}">
-            <span class="fa-solid fa-list me-1" aria-hidden="true"></span>
+            <span class="fa-solid fa-hexagon-nodes me-1" aria-hidden="true"></span>
             <span class="btn-label">{{ 'Revisions'|trans }}</span>
           </a>
           {% if not metadata.isCurrentMetadata %}
@@ -137,6 +150,26 @@
               <span class="fa-solid fa-code-commit me-1" aria-hidden="true"></span>
               <span class="btn-label">{{ 'Current revision'|trans }}</span>
             </a>
+          {% endif %}
+          {% if version.pinned and metadata.isCurrentMetadata %}
+            <form method="post" action="{{ path('dashboard_packages_version_pin', {package: package.name, version: version.name}) }}">
+              <input type="hidden" name="_token" value="{{ csrf_token('unpin-revision-' ~ version.id) }}">
+              <input type="hidden" name="action" value="unpin">
+              <button type="submit" class="btn btn-sm btn-secondary">
+                <span class="fa-solid fa-thumbtack-slash me-1" aria-hidden="true"></span>
+                <span class="btn-label">{{ 'Unpin revision'|trans }}</span>
+              </button>
+            </form>
+          {% elseif not version.pinned %}
+            <form method="post" action="{{ path('dashboard_packages_version_pin', {package: package.name, version: version.name}) }}">
+              <input type="hidden" name="_token" value="{{ csrf_token('pin-revision-' ~ version.id) }}">
+              <input type="hidden" name="action" value="pin">
+              <input type="hidden" name="revision" value="{{ metadata.revision }}">
+              <button type="submit" class="btn btn-sm btn-secondary">
+                <span class="fa-solid fa-thumbtack me-1" aria-hidden="true"></span>
+                <span class="btn-label">{{ 'Pin revision'|trans }}</span>
+              </button>
+            </form>
           {% endif %}
         </div>
       </div>

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -76,9 +76,12 @@ Suggests: Suggests
 Current revision: Current revision
 Indexed on %date%: Indexed on %date%
 Multiple revisions found for version %version% of package %package%: Multiple revisions found for version %version% of package %package%.
+Pin revision: Pin revision
 Revision: Revision
 Revisions: Revisions
 This version has multiple revisions: This version has multiple revisions
+This version is pinned. Future updates will not change the active metadata until it is unpinned.: This version is pinned. Future updates will not change the active metadata until it is unpinned.
+Unpin revision: Unpin revision
 You're viewing an inactive revision of this package: You're viewing an inactive revision of this package.
 
 # Package labels (Statistics)


### PR DESCRIPTION
Adds the ability to pin a package version to a specific revision which prevents it from updating in the future.

See #8 for more information.